### PR TITLE
Automatically increase `step` for large searches

### DIFF
--- a/lib/plugins/EPrints/Plugin/Screen/Report.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/Report.pm
@@ -811,7 +811,6 @@ sub render
 document.observe("dom:loaded", function() {
 	new EPrints_Screen_Report_Loader( {
 		ids: $json,
-		step: 20,
 		prefix: '$prefix',
 		url: '$url',
 		parameters: '$parameters',		

--- a/lib/static/javascript/auto/reports.js
+++ b/lib/static/javascript/auto/reports.js
@@ -71,7 +71,8 @@ var EPrints_Screen_Report_Loader = Class.create({
 	runs: 0,
 	progress: null,
 	ids: Array(),
-	step: 20,
+	step: null,
+	minStep: 20, // If `step` is set to `null` then this is the minimum `step` value
 	prefix: '',
 	onProblems: function() {},
 	onFinish: function() {},
@@ -90,6 +91,8 @@ var EPrints_Screen_Report_Loader = Class.create({
 			this.ids = opts.ids;
 		if( opts.step )
 			this.step = opts.step;
+		if( opts.minStep )
+			this.minStep = opts.minStep;
 		if( opts.prefix )
 			this.prefix = opts.prefix;
 		if( opts.onFinish )
@@ -126,6 +129,15 @@ var EPrints_Screen_Report_Loader = Class.create({
 		var seen_ids = {};
 		this.no_items = this.ids.length;
 		this.retrieved = [];
+
+		// Unless `step` is set this will automatically calculate it depending
+		// on the number of items in the list.
+		// This allows the steps to scale with larger queries (aiming for 100
+		// AJAX requests) so that it doesn't cause Server Errors.
+		if (this.step === null) {
+			this.step = Math.max(Math.round(this.no_items / 100), this.minStep);
+		}
+
 		if( !isInteger(this.ids[0]) ) //ids have been grouped
 		{	
 			grouped = true;


### PR DESCRIPTION
If you have a very large report searches (for example 20000 items) then it should only send a capped amount of AJAX requests to prevent it from spamming the database (eventually leading to Internal Server Errors).

Previously it would always send one request per 20 items (so for our example it would send 1000 separate requests). This means that when you have very large searches this will effectively DOS the server, and eventually reach a point where it starts generating "Error connecting to database: Can't create UNIX socket (24)".

This leaves that option (by setting `step` to a number) however by default `step` will be set automatically to try and send 100 AJAX requests. This is set to be generally enough requests that the loading bar looks reasonable (occasionally you get unlucky and all the requests get replied to together however that is just a flaw with this system of progress reporting).

This doesn't fully resolve the issue with server errors, notably if you do get a server error during the process (for example if the server is busy with other stuff) it will still just sit on a nearly full loading bar with no way of notifying the client. I have another PR planned for that to retry on a failure, however this should make that PR much more effective so I'm landing it first.