### PR TITLE
Repeatedly retry the `Ajax.Request` if it fails

### DIFF
--- a/lib/static/javascript/auto/reports.js
+++ b/lib/static/javascript/auto/reports.js
@@ -164,222 +164,8 @@ var EPrints_Screen_Report_Loader = Class.create({
 					
 				this.container.insert( new Element( 'div', { 'class': 'ep_report_row', 'id': id, 'position': i+j } ), { 'position': 'after' } );
 			}
-			new Ajax.Request( this.url, {
-				method: 'get',
-				parameters: this.parameters + args,
-				onSuccess: (function(transport) {
 
-					var json = transport.responseText.evalJSON();
-					var data = json.data;
-	
-					if( data == null )
-						data = new Array();
-					for( var i=0; i<data.length; i++ )
-					{
-						var entry = data[i];
-				
-						// entry.dataobjid
-						// entry.summary
-						// entry.grouping
-						// entry.problems
-
-						if( entry == null )
-							continue;
-						
-						var dataobjid = entry.dataobjid;
-						if( dataobjid == null )
-							continue;
-						if( !(dataobjid in this.dataobjs) )
-						{
-							this.count++;
-							this.dataobjs[dataobjid] = entry;
-						}
-					}
-			
-					// we've retrieved all the records				
-					if( this.count == this.no_items )
-					{
-						$( this.prefix + '_progress_bar' ).remove();
-						if( this.has_problems )
-							this.onProblems(this);
-						this.onFinish(this);
-							
-						//add the group headings
-						if(grouped)
-						{
-							var position = 0;
-							for( var i = 0; i < this.grouped_ids.length; i++ )
-				                        {	
-								var target_el = document.querySelectorAll('[position="' + position + '"]')[0];
-								position = position + this.grouped_ids[i].list.length;			
-								var grouping_container = new Element( 'div', { 'class': 'ep_report_grouping' } );
-                                                                target_el.insert( { 'before' : grouping_container } );
-                                                                grouping_container.update( this.grouped_ids[i].label );
-				                        }
-						}
-
-						//add the eprint summaries
-						var added_ids = {};
-						for( var c = 0; c < this.ids.length; c++ )
-						{
-							var dataobjid = this.ids[c];
-							var entry = this.dataobjs[dataobjid];
-
-							//store that we have added this objectid
-							if( !(dataobjid in added_ids) )
-							{
-								added_ids[dataobjid] = 0;
-							}
-							else
-							{
-								added_ids[dataobjid] = added_ids[dataobjid] + 1;
-							}
-							this.total_dataobjs++;
-
-							var summary = entry.summary;
-
-							var target_id = this.prefix + '_' + dataobjid;
-							if( added_ids[dataobjid] > 0 )
-							{
-								target_id = target_id + '_' + added_ids[dataobjid];
-							}
-							var target_el = $( target_id );
-
-							if( target_el != null && summary != null )
-							{
-								var summary_el = target_el.appendChild( new Element( 'div', { 'class': 'ep_report_row_summary' } ) );
-								summary_el.update( summary );
-
-								//total up non compliant records
-								if( entry.is_compliant == null && entry.problems && entry.problems.length )
-								{
-									this.total_noncompliant++;
-								}
-								
-								if( entry.problems && entry.problems.length )
-								{
-									var problems_el = target_el.appendChild( new Element( 'ul', { 'class': 'ep_report_row_problems' } ) );
-
-									for( var p=0; p< entry.problems.length; p++ )
-									{
-										var li = problems_el.appendChild( new Element( 'li' ));
-										li.update( entry.problems[p] );
-									}								
-								}
-								else
-								{
-									//add support for compliant items to include bullet points too
-									if( entry.bullets && entry.bullets.length )
-                                                                        {
-                                                                                var bullets_el = target_el.appendChild( new Element( 'ul', { 'class': 'ep_report_row_bullets' } ) );
-
-                                                                                for( var b=0; b< entry.bullets.length; b++ )
-                                                                                {
-                                                                                        var li = bullets_el.appendChild( new Element( 'li' ));
-                                                                                        li.update( entry.bullets[b] );
-                                                                                }
-                                                                        }
-								}
-
-								//display state
-								var re = new RegExp("^#(?:[0-9a-fA-F]{3}){1,2}$");
-								if( entry.state && re.test(entry.state) )
-								{
-									target_el.style.borderLeftWidth = '7px';
-                                                                        target_el.style.borderLeftStyle = 'solid';
-                                                                        target_el.style.borderLeftColor = entry.state;
-								}
-								else //no state provided, so derive one from existence of problems
-								{
-									if( entry.problems && entry.problems.length )
-									{
-										target_el.addClassName( 'ep_report_row_problems' );
-									}
-									else
-									{
-										target_el.addClassName( 'ep_report_row_ok' );
-									}
-
-									if( !this.show_compliance )
-									{
-										target_el.addClassName( 'ep_report_row_no_compliance' );
-									}
-								}								
-								target_el.show();
-
-								var grouping = entry.grouping;
-								if( grouping != null )
-								{
-									if( this.current_grouping == null || this.current_grouping != grouping)
-									{
-										this.current_grouping = grouping;
-										var grouping_container = new Element( 'div', { 'class': 'ep_report_grouping' } );
-										target_el.insert( { 'before' : grouping_container } );
-										grouping_container.update( this.current_grouping );
-									}
-								}
-							}
-						}
-
-
-						if( this.total_dataobjs )
-						{
-							
-							this.container.insertBefore( new Element( 'div', { 'class': 'ep_report_compliance_container', 'id': this.prefix + "_compliance_container" } ), this.container.firstChild );
-							//set up text container
-							$( this.prefix + "_compliance_container" ).appendChild( new Element( 'div', { 'class': 'ep_report_compliance_text', 'id': this.prefix + "_compliance_text",  } ));
-
-							//set up outputs label
-							var outputs;
-							if( this.labels )
-							{
-								outputs = this.labels.outputs;
-							}
-							else
-							{
-								outputs = "output";
-								if( this.total_dataobjs > 1 )
-									outputs = outputs + "s";
-							}
-
-							if( this.show_compliance )
-							{
-								var ref_width = 200;
-								var compliance = ( this.total_dataobjs - this.total_noncompliant ) / this.total_dataobjs;
-
-								$( this.prefix + "_compliance_container" ).appendChild( new Element( 'div', { 'class': 'ep_report_compliance_wrapper', 'id': this.prefix + "_compliance", 'style': 'width: '+ref_width + 'px' } ) );
-
-								var compliance_width = Math.floor( 200 * compliance );
-	
-								$( this.prefix + "_compliance" ).appendChild( new Element( 'div', { 'class': 'ep_report_compliance', 'style': 'width:'+compliance_width + 'px' } ) );
-	
-								$( this.prefix + "_compliance_text" ).update( this.total_dataobjs + " " + outputs + " - " + Math.floor( compliance * 100 ) + "% compliance");
-							}
-							else
-							{
-								$( this.prefix + "_compliance_text" ).update( this.total_dataobjs + " " + outputs );
-							}
-						}	
-
-					}
-					else
-					{
-						var width = 200;
-						$( this.prefix + '_progress_bar' ).style.backgroundPosition = Math.round(-width + width * this.count / this.ids.length) + "px 0px";
-					}
-
-					if( this.runs == 0 && this.count == 0 )
-					{
-						var pNode = $( this.prefix + '_progress_bar' ).parentNode;
-						$(this.prefix + '_progress_bar').remove();
-						var span = new Element( 'span', { 'class': 'ep_ref_report_empty' } );
-						span.update( 'Report empty' );
-						pNode.insert( span );
-					}
-					this.runs++;
-
-				}).bind(this)
-			});
+			makeRequest(this, args, grouped);
 		}
 		if( this.ids == null || this.ids.length == 0 )
 		{
@@ -390,9 +176,226 @@ var EPrints_Screen_Report_Loader = Class.create({
 			pNode.insert( span );
 		}
 	}
-
-
 });
+
+function makeRequest(loader, args, grouped) {
+	new Ajax.Request( loader.url, {
+		method: 'get',
+		parameters: loader.parameters + args,
+		onSuccess: (function(transport) {
+
+			var json = transport.responseText.evalJSON();
+			var data = json.data;
+
+			if( data == null )
+				data = new Array();
+			for( var i=0; i<data.length; i++ )
+			{
+				var entry = data[i];
+
+				// entry.dataobjid
+				// entry.summary
+				// entry.grouping
+				// entry.problems
+
+				if( entry == null )
+					continue;
+
+				var dataobjid = entry.dataobjid;
+				if( dataobjid == null )
+					continue;
+				if( !(dataobjid in this.dataobjs) )
+				{
+					this.count++;
+					this.dataobjs[dataobjid] = entry;
+				}
+			}
+
+			// we've retrieved all the records
+			if( this.count == this.no_items )
+			{
+				$( this.prefix + '_progress_bar' ).remove();
+				if( this.has_problems )
+					this.onProblems(this);
+				this.onFinish(this);
+
+				//add the group headings
+				if(grouped)
+				{
+					var position = 0;
+					for( var i = 0; i < this.grouped_ids.length; i++ )
+					{
+						var target_el = document.querySelectorAll('[position="' + position + '"]')[0];
+						position = position + this.grouped_ids[i].list.length;
+						var grouping_container = new Element( 'div', { 'class': 'ep_report_grouping' } );
+						target_el.insert( { 'before' : grouping_container } );
+						grouping_container.update( this.grouped_ids[i].label );
+					}
+				}
+
+				//add the eprint summaries
+				var added_ids = {};
+				for( var c = 0; c < this.ids.length; c++ )
+				{
+					var dataobjid = this.ids[c];
+					var entry = this.dataobjs[dataobjid];
+
+					//store that we have added this objectid
+					if( !(dataobjid in added_ids) )
+					{
+						added_ids[dataobjid] = 0;
+					}
+					else
+					{
+						added_ids[dataobjid] = added_ids[dataobjid] + 1;
+					}
+					this.total_dataobjs++;
+
+					var summary = entry.summary;
+
+					var target_id = this.prefix + '_' + dataobjid;
+					if( added_ids[dataobjid] > 0 )
+					{
+						target_id = target_id + '_' + added_ids[dataobjid];
+					}
+					var target_el = $( target_id );
+
+					if( target_el != null && summary != null )
+					{
+						var summary_el = target_el.appendChild( new Element( 'div', { 'class': 'ep_report_row_summary' } ) );
+						summary_el.update( summary );
+
+						//total up non compliant records
+						if( entry.is_compliant == null && entry.problems && entry.problems.length )
+						{
+							this.total_noncompliant++;
+						}
+
+						if( entry.problems && entry.problems.length )
+						{
+							var problems_el = target_el.appendChild( new Element( 'ul', { 'class': 'ep_report_row_problems' } ) );
+
+							for( var p=0; p< entry.problems.length; p++ )
+							{
+								var li = problems_el.appendChild( new Element( 'li' ));
+								li.update( entry.problems[p] );
+							}
+						}
+						else
+						{
+							//add support for compliant items to include bullet points too
+							if( entry.bullets && entry.bullets.length )
+							{
+								var bullets_el = target_el.appendChild( new Element( 'ul', { 'class': 'ep_report_row_bullets' } ) );
+
+								for( var b=0; b< entry.bullets.length; b++ )
+								{
+									var li = bullets_el.appendChild( new Element( 'li' ));
+									li.update( entry.bullets[b] );
+								}
+							}
+						}
+
+						//display state
+						var re = new RegExp("^#(?:[0-9a-fA-F]{3}){1,2}$");
+						if( entry.state && re.test(entry.state) )
+						{
+							target_el.style.borderLeftWidth = '7px';
+							target_el.style.borderLeftStyle = 'solid';
+							target_el.style.borderLeftColor = entry.state;
+						}
+						else //no state provided, so derive one from existence of problems
+						{
+							if( entry.problems && entry.problems.length )
+							{
+								target_el.addClassName( 'ep_report_row_problems' );
+							}
+							else
+							{
+								target_el.addClassName( 'ep_report_row_ok' );
+							}
+
+							if( !this.show_compliance )
+							{
+								target_el.addClassName( 'ep_report_row_no_compliance' );
+							}
+						}
+						target_el.show();
+
+						var grouping = entry.grouping;
+						if( grouping != null )
+						{
+							if( this.current_grouping == null || this.current_grouping != grouping)
+							{
+								this.current_grouping = grouping;
+								var grouping_container = new Element( 'div', { 'class': 'ep_report_grouping' } );
+								target_el.insert( { 'before' : grouping_container } );
+								grouping_container.update( this.current_grouping );
+							}
+						}
+					}
+				}
+
+
+				if( this.total_dataobjs )
+				{
+
+					this.container.insertBefore( new Element( 'div', { 'class': 'ep_report_compliance_container', 'id': this.prefix + "_compliance_container" } ), this.container.firstChild );
+					//set up text container
+					$( this.prefix + "_compliance_container" ).appendChild( new Element( 'div', { 'class': 'ep_report_compliance_text', 'id': this.prefix + "_compliance_text",  } ));
+
+					//set up outputs label
+					var outputs;
+					if( this.labels )
+					{
+						outputs = this.labels.outputs;
+					}
+					else
+					{
+						outputs = "output";
+						if( this.total_dataobjs > 1 )
+							outputs = outputs + "s";
+					}
+
+					if( this.show_compliance )
+					{
+						var ref_width = 200;
+						var compliance = ( this.total_dataobjs - this.total_noncompliant ) / this.total_dataobjs;
+
+						$( this.prefix + "_compliance_container" ).appendChild( new Element( 'div', { 'class': 'ep_report_compliance_wrapper', 'id': this.prefix + "_compliance", 'style': 'width: '+ref_width + 'px' } ) );
+
+						var compliance_width = Math.floor( 200 * compliance );
+
+						$( this.prefix + "_compliance" ).appendChild( new Element( 'div', { 'class': 'ep_report_compliance', 'style': 'width:'+compliance_width + 'px' } ) );
+
+						$( this.prefix + "_compliance_text" ).update( this.total_dataobjs + " " + outputs + " - " + Math.floor( compliance * 100 ) + "% compliance");
+					}
+					else
+					{
+						$( this.prefix + "_compliance_text" ).update( this.total_dataobjs + " " + outputs );
+					}
+				}
+
+			}
+			else
+			{
+				var width = 200;
+				$( this.prefix + '_progress_bar' ).style.backgroundPosition = Math.round(-width + width * this.count / this.ids.length) + "px 0px";
+			}
+
+			if( this.runs == 0 && this.count == 0 )
+			{
+				var pNode = $( this.prefix + '_progress_bar' ).parentNode;
+				$(this.prefix + '_progress_bar').remove();
+				var span = new Element( 'span', { 'class': 'ep_ref_report_empty' } );
+				span.update( 'Report empty' );
+				pNode.insert( span );
+			}
+			this.runs++;
+
+		}).bind(loader)
+	});
+}
 
 function group_report(group)
 {

--- a/lib/static/javascript/auto/reports.js
+++ b/lib/static/javascript/auto/reports.js
@@ -119,9 +119,9 @@ var EPrints_Screen_Report_Loader = Class.create({
 
 		this.container.insert( new Element( 'div', { 'class': 'ep_report_progress_bar', 'id': this.prefix + "_progress_bar" } ) );	
 
-		var current_grouping = null;	// might not be set in the returned value but that's allowed/OK
+		this.current_grouping = null;	// might not be set in the returned value but that's allowed/OK
 
-		var dataobjs = {};
+		this.dataobjs = {};
 		var grouped = false;
 		var seen_ids = {};
 		this.no_items = this.ids.length;
@@ -189,10 +189,10 @@ var EPrints_Screen_Report_Loader = Class.create({
 						var dataobjid = entry.dataobjid;
 						if( dataobjid == null )
 							continue;
-						if( !(dataobjid in dataobjs) )
+						if( !(dataobjid in this.dataobjs) )
 						{
 							this.count++;
-							dataobjs[dataobjid] = entry;
+							this.dataobjs[dataobjid] = entry;
 						}
 					}
 			
@@ -223,7 +223,7 @@ var EPrints_Screen_Report_Loader = Class.create({
 						for( var c = 0; c < this.ids.length; c++ )
 						{
 							var dataobjid = this.ids[c];
-							var entry = dataobjs[dataobjid];
+							var entry = this.dataobjs[dataobjid];
 
 							//store that we have added this objectid
 							if( !(dataobjid in added_ids) )
@@ -310,12 +310,12 @@ var EPrints_Screen_Report_Loader = Class.create({
 								var grouping = entry.grouping;
 								if( grouping != null )
 								{
-									if( current_grouping == null || current_grouping != grouping)
+									if( this.current_grouping == null || this.current_grouping != grouping)
 									{
-										current_grouping = grouping;
+										this.current_grouping = grouping;
 										var grouping_container = new Element( 'div', { 'class': 'ep_report_grouping' } );
 										target_el.insert( { 'before' : grouping_container } );
-										grouping_container.update( current_grouping );
+										grouping_container.update( this.current_grouping );
 									}
 								}
 							}

--- a/lib/static/javascript/auto/reports.js
+++ b/lib/static/javascript/auto/reports.js
@@ -182,6 +182,13 @@ function makeRequest(loader, args, grouped) {
 	new Ajax.Request( loader.url, {
 		method: 'get',
 		parameters: loader.parameters + args,
+		onFailure: () => {
+			// Retry after 100ms if the query fails (such as to an Internal
+			// Server Error).
+			setTimeout(() => {
+				makeRequest(loader, args, grouped);
+			}, 100);
+		},
 		onSuccess: (function(transport) {
 
 			var json = transport.responseText.evalJSON();


### PR DESCRIPTION
Rather than just never finishing loading if a single AJAX request fails (as the `count` will never match the `total_no`), it should instead retry.

To try and prevent it from hammering an already struggling server this makes it wait 100ms between any retry, there should potentially be a backoff or retry cap to fully stop this if it repeatedly fails (such as if the DB is offline).